### PR TITLE
Build Script outputs config file,  output clearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+zkeyFiles

--- a/scripts/build-circuits.sh
+++ b/scripts/build-circuits.sh
@@ -2,43 +2,58 @@
 set -e
 
 cd "$(dirname "$0")"
-
+zkeypath="../zkeyFiles"
 mkdir -p ../build/contracts
 mkdir -p ../build/setup
-mkdir -p ../build/zkeyFiles
+mkdir -p $zkeypath
 
 # Build context
 cd ../build
-
+echo -e "\033[36m----------------------\033[0m"
+echo -e "\033[36mSETTING UP ENVIRONMENT\033[0m"
+echo -e "\033[36m----------------------\033[0m"
 if [ -f ./powersOfTau28_hez_final_14.ptau ]; then
-    echo "powersOfTau28_hez_final_14.ptau already exists. Skipping."
+    echo -e "\033[33mpowersOfTau28_hez_final_14.ptau already exists. Skipping.\033[0m"
 else
-    echo "Downloading powersOfTau28_hez_final_14.ptau"
+    echo -e "\033[33mDownloading powersOfTau28_hez_final_14.ptau\033[0m"
     wget https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_14.ptau
 fi
 
-circuit_path="../circuits/rln-same.circom"
-
-echo "$PWD"
+circuit_path=""
+circuit_type=""
+if [ "$1" = "diff" ]; then
+    echo -e "\033[32mUsing Diff circuit\033[0m"
+    circuit_type="diff"
+    circuit_path="../circuits/rln-diff.circom"
+elif [ "$1" = "same" ]; then
+    echo -e "\033[32mUsing Same circuit\033[0m"
+    circuit_type="same"
+    circuit_path="../circuits/rln-same.circom"
+else
+    circuit_type="same"
+    circuit_path="../circuits/rln-same.circom"
+    echo -e "\033[33mUnrecognized argument, using 'same' as default.\033[0m"
+fi
 
 if ! [ -x "$(command -v circom)" ]; then
-    echo 'Error: circom is not installed.' >&2
-    echo 'Error: please install circom: https://docs.circom.io/getting-started/installation/.' >&2
+    echo -e '\033[31mError: circom is not installed.\033[0m' >&2
+    echo -e '\033[31mError: please install circom: https://docs.circom.io/getting-started/installation/.\033[0m' >&2
     exit 1
 fi
 
-echo "Circuit path: $circuit_path"
+echo -e "Circuit path: $circuit_path"
+echo -e "\033[36m-----------------\033[0m"
+echo -e "\033[36mCOMPILING CIRCUIT\033[0m"
+echo -e "\033[36m-----------------\033[0m"
 
-which -a circom
-echo "-----------------"
-echo "COMPILING CIRCUIT"
-echo "-----------------"
+echo -e "\033[36m Build Path: $PWD\033[0m"
+
 circom --version
 circom $circuit_path --r1cs --wasm --sym
 
 snarkjs r1cs export json rln-same.r1cs rln-same.r1cs.json
 
-echo "Running groth16 trusted setup"
+echo -e "\033[36mRunning groth16 trusted setup\033[0m"
 
 snarkjs groth16 setup rln-same.r1cs powersOfTau28_hez_final_14.ptau setup/rln_0000.zkey
 
@@ -46,10 +61,16 @@ snarkjs zkey contribute setup/rln_0000.zkey setup/rln_0001.zkey --name="First co
 snarkjs zkey contribute setup/rln_0001.zkey setup/rln_0002.zkey --name="Second contribution" -v -e="Another random entropy"
 snarkjs zkey beacon setup/rln_0002.zkey setup/rln_final.zkey 0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 10 -n="Final Beacon phase2"
 
-echo "Exporting artifacts to zkeyFiles and contracts directory"
+echo -e "Exporting artifacts to zkeyFiles and contracts directory"
 
-snarkjs zkey export verificationkey setup/rln_final.zkey zkeyFiles/verification_key.json
+snarkjs zkey export verificationkey setup/rln_final.zkey $zkeypath/verification_key.json
 snarkjs zkey export solidityverifier setup/rln_final.zkey contracts/verifier.sol
 
-cp rln-same_js/rln-same.wasm zkeyFiles/rln-same.wasm
-cp setup/rln_final.zkey zkeyFiles/rln_final.zkey
+cp rln-same_js/rln-same.wasm $zkeypath/rln-same.wasm
+cp setup/rln_final.zkey $zkeypath/rln_final.zkey
+
+echo -e "RLN_Version: V2" > $zkeypath/circuit.config
+echo -e "RLN_Type: $circuit_type" >> $zkeypath/circuit.config
+echo -e "GitHub_URL: $(git config --get remote.origin.url)"  >> $zkeypath/circuit.config
+echo -e "Git_Commit: $(git describe --always)" >> $zkeypath/circuit.config
+echo -e "Compilation_Time: $(date +%s)" >> $zkeypath/circuit.config

--- a/scripts/build-circuits.sh
+++ b/scripts/build-circuits.sh
@@ -46,7 +46,7 @@ echo -e "\033[36m-----------------\033[0m"
 echo -e "\033[36mCOMPILING CIRCUIT\033[0m"
 echo -e "\033[36m-----------------\033[0m"
 
-echo -e "\033[36m Build Path: $PWD\033[0m"
+echo -e "\033[36mBuild Path: $PWD\033[0m"
 
 circom --version
 circom $circuit_path --r1cs --wasm --sym
@@ -66,11 +66,30 @@ echo -e "Exporting artifacts to zkeyFiles and contracts directory"
 snarkjs zkey export verificationkey setup/rln_final.zkey $zkeypath/verification_key.json
 snarkjs zkey export solidityverifier setup/rln_final.zkey contracts/verifier.sol
 
-cp rln-same_js/rln-same.wasm $zkeypath/rln-same.wasm
+cp rln-$circuit_type\_js/rln-$circuit_type.wasm $zkeypath/rln.wasm
 cp setup/rln_final.zkey $zkeypath/rln_final.zkey
 
-echo -e "RLN_Version: V2" > $zkeypath/circuit.config
-echo -e "RLN_Type: $circuit_type" >> $zkeypath/circuit.config
-echo -e "GitHub_URL: $(git config --get remote.origin.url)"  >> $zkeypath/circuit.config
-echo -e "Git_Commit: $(git describe --always)" >> $zkeypath/circuit.config
-echo -e "Compilation_Time: $(date +%s)" >> $zkeypath/circuit.config
+config_path="$zkeypath/circuit.config.toml"
+echo -e "[Circuit_Version]" > $config_path
+echo -e "RLN_Version = 2" >> $config_path
+echo -e "RLN_Type = \"$circuit_type\"" >> $config_path
+
+echo -e "" >> $config_path
+
+echo -e "[Circuit_Build]" >> $config_path
+echo -e "Circom_Version = \"$(circom --version)\"" >> $config_path
+echo -e "GitHub_URL = \"$(git config --get remote.origin.url)\""  >> $config_path
+echo -e "Git_Commit = \"$(git describe --always)\"" >> $config_path
+echo -e "Compilation_Time = $(date +%s)" >> $config_path
+
+echo -e "" >> $config_path
+echo -e "[Files]" >> $config_path
+echo -e "Wasm = \"rln.wasm\"" >> $config_path
+wasm_sha256=$(sha256sum $zkeypath/rln.wasm | awk '{print $1}')
+echo -e "Wasm_SHA256SUM = \"$wasm_sha256\"" >> $config_path
+echo -e "Zkey = \"rln_final.zkey\"" >> $config_path
+zkey_sha256=$(sha256sum $zkeypath/rln_final.zkey | awk '{print $1}')
+echo -e "Zkey_SHA256SUM = \"$zkey_sha256\"" >> $config_path
+echo -e "Verification_Key = \"verification_key.json\"" >> $config_path
+vkey_sha256=$(sha256sum $zkeypath/verification_key.json | awk '{print $1}')
+echo -e "Verification_Key_SHA256SUM = \"$vkey_sha256\"" >> $config_path

--- a/scripts/build-circuits.sh
+++ b/scripts/build-circuits.sh
@@ -69,6 +69,8 @@ snarkjs zkey export solidityverifier setup/rln_final.zkey contracts/verifier.sol
 cp rln-$circuit_type\_js/rln-$circuit_type.wasm $zkeypath/rln.wasm
 cp setup/rln_final.zkey $zkeypath/rln_final.zkey
 
+shasumcmd="shasum -a 256"
+
 config_path="$zkeypath/circuit.config.toml"
 echo -e "[Circuit_Version]" > $config_path
 echo -e "RLN_Version = 2" >> $config_path
@@ -85,11 +87,11 @@ echo -e "Compilation_Time = $(date +%s)" >> $config_path
 echo -e "" >> $config_path
 echo -e "[Files]" >> $config_path
 echo -e "Wasm = \"rln.wasm\"" >> $config_path
-wasm_sha256=$(sha256sum $zkeypath/rln.wasm | awk '{print $1}')
+wasm_sha256=$($shasumcmd $zkeypath/rln.wasm | awk '{print $1}')
 echo -e "Wasm_SHA256SUM = \"$wasm_sha256\"" >> $config_path
 echo -e "Zkey = \"rln_final.zkey\"" >> $config_path
-zkey_sha256=$(sha256sum $zkeypath/rln_final.zkey | awk '{print $1}')
+zkey_sha256=$($shasumcmd $zkeypath/rln_final.zkey | awk '{print $1}')
 echo -e "Zkey_SHA256SUM = \"$zkey_sha256\"" >> $config_path
 echo -e "Verification_Key = \"verification_key.json\"" >> $config_path
-vkey_sha256=$(sha256sum $zkeypath/verification_key.json | awk '{print $1}')
+vkey_sha256=$($shasumcmd $zkeypath/verification_key.json | awk '{print $1}')
 echo -e "Verification_Key_SHA256SUM = \"$vkey_sha256\"" >> $config_path


### PR DESCRIPTION
* Improves the command line output to be clearer
* Relocated `zkeyFiles` folder to the root project directory
* Added `zkeyFiles` folder to `.gitignore`
* Outputs a `circuit.config.toml` to the `zkeyFiles` folder:
```
[Circuit_Version]
RLN_Version = 2
RLN_Type = "same"

[Circuit_Build]
Circom_Version = "circom compiler 2.1.4"
GitHub_URL = "https://github.com/Rate-Limiting-Nullifier/rln-circuits-v2.git"
Git_Commit = "8961ad6"
Compilation_Time = 1678765596

[Files]
Wasm = "rln.wasm"
Wasm_SHA256SUM = "05cfefe0c1f82aa507b1d8c7cae66ddafcc283f159d4afd2b7dbdb36e8ef49a9"
Zkey = "rln_final.zkey"
Zkey_SHA256SUM = "9e139356955e87c6669bccc841f56003b93c0306787d3e97e952494d4f404704"
Verification_Key = "verification_key.json"
Verification_Key_SHA256SUM = "c2c352096b3a04a1379af9394ae19b6a5a82ff8467d8be61cd85b85d61c345e8"

```