### PR TITLE
Add multi-proof with multiple epochs

### DIFF
--- a/circuits/rln-diff-dualepoch.circom
+++ b/circuits/rln-diff-dualepoch.circom
@@ -1,0 +1,62 @@
+pragma circom 2.1.0;
+
+include "./incrementalMerkleTree.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+
+template IsInInterval(n) {
+    signal input in[3];
+
+    signal output out;
+
+    signal let <== LessEqThan(n)([in[1], in[2]]);
+    signal get <== GreaterEqThan(n)([in[1], in[0]]);
+
+    out <== let * get;
+}
+
+template RLN(DEPTH, LIMIT_BIT_SIZE) {
+    // Private signals
+    signal input identitySecret;
+    signal input userMessageLimitA;
+    signal input userMessageLimitB;
+    signal input messageIdA;
+    signal input messageIdB;
+    signal input pathElements[DEPTH];
+    signal input identityPathIndex[DEPTH];
+
+    // Public signals
+    signal input x;
+    signal input externalNullifierA;
+    signal input externalNullifierB;
+
+    // Outputs
+    signal output yA;
+    signal output yB;
+    signal output root;
+    signal output nullifierA;
+    signal output nullifierB;
+
+    signal identityCommitment <== Poseidon(1)([identitySecret]);
+    signal rateCommitment <== Poseidon(3)([identityCommitment, userMessageLimitA, userMessageLimitB]);
+
+    root <== MerkleTreeInclusionProof(DEPTH)(rateCommitment, identityPathIndex, pathElements);
+
+    signal checkIntervalA <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIdA, userMessageLimitA]);
+    checkIntervalA === 1;
+
+    signal checkIntervalB <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIdB, userMessageLimitB]);
+    checkIntervalB === 1;
+    
+    signal a1_A <== Poseidon(4)([identitySecret, externalNullifierA, messageIdA, 1]);
+    yA <== identitySecret + a1_A * x;
+
+    nullifierA <== Poseidon(1)([a1_A]);
+
+    signal a1_B <== Poseidon(4)([identitySecret, externalNullifierB, messageIdB, 2]);
+    yB <== identitySecret + a1_B * x;
+
+    nullifierB <== Poseidon(1)([a1_B]);
+}
+
+component main { public [x, externalNullifierA, externalNullifierB] } = RLN(20, 16);

--- a/circuits/rln-multi.circom
+++ b/circuits/rln-multi.circom
@@ -1,0 +1,59 @@
+pragma circom 2.1.0;
+
+include "./incrementalMerkleTree.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+
+template IsInInterval(n) {
+    signal input in[3];
+
+    signal output out;
+
+    signal let <== LessEqThan(n)([in[1], in[2]]);
+    signal get <== GreaterEqThan(n)([in[1], in[0]]);
+
+    out <== let * get;
+}
+
+template RLN(DEPTH, LIMIT_BIT_SIZE) {
+    // Private signals
+    signal input identitySecret;
+    signal input messageId;
+    signal input pathElements[DEPTH];
+    signal input identityPathIndex[DEPTH];
+
+    // Public signals
+    signal input x;
+    signal input externalNullifierMultiMessage; // Nullifier that can be reused with different message IDs
+    signal input messageLimit;
+
+    signal input externalNullifierSingleMessage; // Nullifier that must be unique
+
+    // Outputs
+    signal output root;
+    // Multiple message ID related
+    signal output y_mm;
+    signal output nullifierMultiMessage;
+    // Single message ID related
+    signal output y_sm;
+    signal output nullifierSingleMessage;
+
+    signal identityCommitment <== Poseidon(1)([identitySecret]);
+
+    root <== MerkleTreeInclusionProof(DEPTH)(identityCommitment, identityPathIndex, pathElements);
+
+    signal checkInterval <== IsInInterval(LIMIT_BIT_SIZE)([1, messageId, messageLimit]);
+    checkInterval === 1;
+
+    signal a1_mm <== Poseidon(3)([identitySecret, externalNullifierMultiMessage, messageId]);
+    y_mm <== identitySecret + a1_mm * x;
+
+    nullifierMultiMessage <== Poseidon(1)([a1_mm]);
+
+    signal a1_sm <== Poseidon(2)([identitySecret, externalNullifierSingleMessage]);
+    y_sm <== identitySecret + a1_sm * x;
+
+    nullifierSingleMessage <== Poseidon(1)([a1_sm]);
+}
+
+component main { public [x, externalNullifierMultiMessage, messageLimit, externalNullifierSingleMessage] } = RLN(20, 16);

--- a/circuits/rln-same-dualepoch.circom
+++ b/circuits/rln-same-dualepoch.circom
@@ -1,0 +1,61 @@
+pragma circom 2.1.0;
+
+include "./incrementalMerkleTree.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
+
+template IsInInterval(n) {
+    signal input in[3];
+
+    signal output out;
+
+    signal let <== LessEqThan(n)([in[1], in[2]]);
+    signal get <== GreaterEqThan(n)([in[1], in[0]]);
+
+    out <== let * get;
+}
+
+template RLN(DEPTH, LIMIT_BIT_SIZE) {
+    // Private signals
+    signal input identitySecret;
+    signal input messageIdA;
+    signal input messageIdB;
+    signal input pathElements[DEPTH];
+    signal input identityPathIndex[DEPTH];
+
+    // Public signals
+    signal input x;
+    signal input externalNullifierA;
+    signal input messageLimitA;
+    signal input externalNullifierB;
+    signal input messageLimitB;
+
+    // Outputs
+    signal output yA;
+    signal output yB;
+    signal output root;
+    signal output nullifierA;
+    signal output nullifierB;
+
+    signal identityCommitment <== Poseidon(1)([identitySecret]);
+
+    root <== MerkleTreeInclusionProof(DEPTH)(identityCommitment, identityPathIndex, pathElements);
+
+    signal checkIntervalA <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIdA, messageLimitA]);
+    checkIntervalA === 1;
+
+    signal checkIntervalB <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIdB, messageLimitB]);
+    checkIntervalB === 1;
+
+    signal a1_A <== Poseidon(4)([identitySecret, externalNullifierA, messageIdA, 1]);
+    yA <== identitySecret + a1_A * x;
+
+    nullifierA <== Poseidon(1)([a1_A]);
+
+    signal a1_B <== Poseidon(4)([identitySecret, externalNullifierB, messageIdB, 2]);
+    yB <== identitySecret + a1_B * x;
+
+    nullifierB <== Poseidon(1)([a1_B]);
+}
+
+component main { public [x, externalNullifierA, messageLimitA, externalNullifierB, messageLimitB] } = RLN(20, 16);


### PR DESCRIPTION
Being able to use multiple epochs at the same time in a single proof would be very useful, especially in conjunction with messageIds.

The classic RLN scheme is one-message-per-epoch.
This works but creates a difficult tradeoff.

For example, if we are building a chat application, anything less than 1 message per second becomes disruptive to the user experience. Still, 1 message per second is 3600 per hour, leaving the system open for exploitation.
Increasing the epoch time is bad for UX and only somewhat limits spammers.

So messageIds were added to the circuit ("n-messages-per-epoch"), which allows us to do things like limiting users to ~2000 messages per day without adding any forced delay between messages.

However, I believe that this is not strong enough by itself, and that one-message-per-epoch has a very useful property: it forces a spammer who wants to send many messages at once to date them backwards in time. To send N messages, you need to date the Nth N epochs back.
At an app level this back-dating can be penalized. Any application with a real time feed would insert said messages at an earlier point in said feed, alongside older messages, not to be seen by users who already scrolled past.

Beyond that, I think having multiple epochs (with multiple message IDs) is useful since it allows for much more sensible and granular rate limiting. For example, 100 messages per hour, 2000 per day.

This can all be accomplished with multiple proofs, however that takes up a lot of extra space on messages, and is expensive to compute, *especially* given each proof has to independently prove the merkle tree membership.

I wrote a circuit which combines the original RLN proof with the new messageId proof, specifically the `rln-same` version.

We have two external nullifiers, one with messageId, and one without. Therefore we generate two internal nullifiers, and two yShares.
In this case, given one doesn't have a message Id, there is no risk of leaking the key if the two external nullifiers are the same.

A generalization of this circuit would have both be paired with a messageId, allowing for two separate rate limits as I discussed. I might make that, it would be pretty trivial, just as it would be trivial to apply this idea to `rln-diff`, however for my purposes, given I only want to pair one messageId rate limit to one-post-per-epoch, this is good enough and it's important to be economical as these proofs are slow to compute.

Note: The version with two message Ids is potentially dangerous if too naively implemented/used. An honest user could generate a proof with the same epoch on both sides, and the same message ID. In the example before, the first message of the day if we sent it right at midnight. That would leak his secret immediately.
This problem can be avoided by adding a fixed constant value to both nullifiers that is different between them. Might be built into the proof itself?

On my system it took 2 seconds to generate a proof, compared to 1.5 seconds for the basic `rln` proof (without messageId), which is acceptable. However it took me 1.35 seconds to verify this proof, compared to 400ms for the basic one. Which is ludicrous.

I don't see a way to make it faster though. It might be too slow to verify for my use case, unfortunately.

EDIT: The speed issue might've been a fluke. I am getting the same performance now.