### PR TITLE
Generalized RLN circuit with multiplier

### DIFF
--- a/circuits/rln-generic.circom
+++ b/circuits/rln-generic.circom
@@ -1,0 +1,43 @@
+pragma circom 2.1.0;
+
+include "./utils.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+
+template RLN(DEPTH, LIMIT_BIT_SIZE, NULLIFIERS) {
+    // Private signals
+    signal input identitySecret;
+    signal input userMessageLimitMultiplier;
+    signal input messageIds[NULLIFIERS];
+    signal input pathElements[DEPTH];
+    signal input identityPathIndex[DEPTH];
+
+    // Public signals
+    signal input x;
+    signal input externalNullifiers[NULLIFIERS];
+    signal input messageLimits[NULLIFIERS];
+
+    // Outputs
+    signal output y[NULLIFIERS];
+    signal output root;
+    signal output nullifiers[NULLIFIERS];
+
+    signal identityCommitment <== Poseidon(1)([identitySecret]);
+    signal rateCommitment <== Poseidon(2)([identityCommitment, userMessageLimitMultiplier]);
+
+    root <== MerkleTreeInclusionProof(DEPTH)(rateCommitment, identityPathIndex, pathElements);
+
+    signal userMessageLimits[NULLIFIERS];
+    signal checkIntervals[NULLIFIERS];
+    signal a1[NULLIFIERS];
+
+    for (var i = 0; i < NULLIFIERS; i++) {
+        userMessageLimits[i] <== messageLimits[i] * userMessageLimitMultiplier;
+        checkIntervals[i] <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIds[i], userMessageLimits[i]]);
+        checkIntervals[i] === 1;
+        a1[i] <== Poseidon(4)([identitySecret, externalNullifiers[i], messageIds[i], i]);
+        y[i] <== identitySecret + a1[i] * x;
+        nullifiers[i] <== Poseidon(1)([a1[i]]);
+    }
+}
+
+component main { public [x, externalNullifiers, messageLimits] } = RLN(20, 16, 2);


### PR DESCRIPTION
I've come up with a more generalized formulation of the RLN circuit which covers all the features implemented by the various v2 circuits on this repo (diff/same) as well as my idea of having multiple nullifiers per proof, but templated so you can have N nullifiers.

I think this could be the single circuit for RLN, since it can do anything the others can.

Here's the idea:
I wanted to use RLN-Diff which allows users to have different rate limits bases on information in the merkle tree, which could be done through, for example, providing a higher deposit into a membership contract.

The problem is I found RLN-Diff to be too inflexible. It only allows a single global messageLimit though it can differ on a per user basis, applications using RLN might often have different message types that need different message rates.

Furthermore, as discussed in https://github.com/Rate-Limiting-Nullifier/rln-circuits-v2/pull/2 , it's actually very useful to have multiple epochs/nullifiers on a single signal (and therefore multiple messageLimits), such as 100 messages per hour, 1000 messages per day. Most real world use cases for RLN would likely benefit from such a tiered approach.

This is currently impossible with RLN-Diff, even in the multi-nullifier version I proposed.

My solution was to keep messageLimits public, and make the user limit value included in the merkle tree a *multiplier* for messageLimits.

Essentially we do the same as with RLN-Same, with exposed messageLimits, but multiply them internally by the secret multiplier for that specific user before doing the range check.
This can produce the same behaviour as RLN-Same if we impose that the multiplier saved into the tree always be "1".
Or it can be the same as RLN-Diff, if we impose that all message limits be "1".

It's extremely flexible since it can do everything they can, and it can also work like the original RLN if we require both values be "1".

I think a "multiplier" value maps well to real world use cases. The idea being that we first decide what rate limits a normal, average user should have, and impose that those be set as messageLimits on any proofs required by our protocol.
Then, logically, normal users would get a multiplier of 1 by default.
However, specific "power users" might deposit a multiplier of the required base deposit into our group membership contract, and logically get a corresponding multiplier on their rate limit.
This doesn't allow for someone to signal for say, 1.5x the messageLimit, because the multiplier is an integer, but I don't think it would be used that way in practice.
The option of having "1" as the base user multiplier, and then being able to act like multiple users by depositing multiples of the default deposit seems much more likely to me.

Finally, I made the template generic over the number of nullifiers per proof we need. This allows for the tiered rate limiting approach I described last time, except that now we have less code and can easily alter the number of nullifiers.

I should say that this templating does not add any overhead by itself at all. If you set NULLIFIERS = 1 you get the same circuit as you would writing a single nullifier normally, like the circuits already in this repo. Which is why I think this circuit should be included, even if you're unsure about how many nullifiers is ideal.
It can replace everything else in terms of functionality depending on the parameters you set.

Once you decide to work on the trusted setup ceremony you will decide what number of nullifiers to use, just like you'll have to decide on tree depth, it's no different.

But I do recommend using this circuit since it can be configured easily.