### PR TITLE
Node JS Buildscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 zkeyFiles
+tau

--- a/circuits/rln-generic.circom
+++ b/circuits/rln-generic.circom
@@ -1,0 +1,43 @@
+pragma circom 2.1.0;
+
+include "./utils.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+
+template RLN(DEPTH, LIMIT_BIT_SIZE, NULLIFIERS) {
+    // Private signals
+    signal input identitySecret;
+    signal input userMessageLimitMultiplier;
+    signal input messageIds[NULLIFIERS];
+    signal input pathElements[DEPTH];
+    signal input identityPathIndex[DEPTH];
+
+    // Public signals
+    signal input x;
+    signal input externalNullifiers[NULLIFIERS];
+    signal input messageLimits[NULLIFIERS];
+
+    // Outputs
+    signal output y[NULLIFIERS];
+    signal output root;
+    signal output nullifiers[NULLIFIERS];
+
+    signal identityCommitment <== Poseidon(1)([identitySecret]);
+    signal rateCommitment <== Poseidon(2)([identityCommitment, userMessageLimitMultiplier]);
+
+    root <== MerkleTreeInclusionProof(DEPTH)(rateCommitment, identityPathIndex, pathElements);
+
+    signal userMessageLimits[NULLIFIERS];
+    signal checkIntervals[NULLIFIERS];
+    signal a1[NULLIFIERS];
+
+    for (var i = 0; i < NULLIFIERS; i++) {
+        userMessageLimits[i] <== messageLimits[i] * userMessageLimitMultiplier;
+        checkIntervals[i] <== IsInInterval(LIMIT_BIT_SIZE)([1, messageIds[i], userMessageLimits[i]]);
+        checkIntervals[i] === 1;
+        a1[i] <== Poseidon(4)([identitySecret, externalNullifiers[i], messageIds[i], i]);
+        y[i] <== identitySecret + a1[i] * x;
+        nullifiers[i] <== Poseidon(1)([a1[i]]);
+    }
+}
+
+component main { public [x, externalNullifiers, messageLimits] } = RLN(20, 16, 2);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-       "build": "node scripts/build.js",
+       "build": "node scripts/build.js"
     },
     "devDependencies": {
         "circomlib": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "build": "bash scripts/build-circuits.sh"
+       "build": "node scripts/build.js",
     },
     "devDependencies": {
         "circomlib": "^2.0.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,63 @@
+const { execSync } = require("child_process")
+const { mkdirSync, renameSync, rmSync, existsSync } = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+
+function execPrint(cmd) {
+    console.log(execSync(cmd).toString())
+}
+
+function run(name, scheme, tauname) {
+    const root = process.cwd()
+    const tauFile = path.join(root, 'tau', tauname)
+    const build = path.join(root, 'build')
+    const circuitFile = path.join(root, 'circuits', name+'.circom')
+    const setup = path.join(build, 'setup', scheme, name)
+    const dest = path.join(root, 'compiled', name)
+    if (!existsSync(tauFile)) {
+        const tauURL = `https://hermez.s3-eu-west-1.amazonaws.com/${tauname}`
+        console.error(`You must download ${tauURL} and save it to ${tauFile}`)
+        return
+    }
+    rmSync(build, {recursive: true, force: true})
+
+    mkdirSync(setup, {recursive: true})
+    mkdirSync(path.join(dest, scheme), {recursive: true})
+
+    process.chdir(build)
+    execPrint(`circom ${circuitFile} --r1cs --wasm --sym`)
+
+    rmSync(path.join(dest, 'js'), {recursive: true, force: true})
+    renameSync(path.join(build, `${name}_js`, `${name}.wasm`), path.join(build, `${name}_js`, `circuit.wasm`))
+    renameSync(path.join(build, `${name}_js`), path.join(dest, 'js'), {force: true})
+
+    execPrint(`snarkjs r1cs export json ${name}.r1cs ${name}.r1cs.json`)
+    if (scheme == 'groth16') {
+        execPrint(`snarkjs groth16 setup ${name}.r1cs ${tauFile} ${path.join(setup, 'rln_0000.zkey')} `)
+        execPrint(`snarkjs zkey contribute ${path.join(setup, 'rln_0000.zkey')} ${path.join(setup, 'rln_0001.zkey')} --name="First contribution" -v -e="${crypto.randomBytes(16).toString('hex')}"`)
+        execPrint(`snarkjs zkey contribute ${path.join(setup, 'rln_0001.zkey')} ${path.join(setup, 'rln_0002.zkey')} --name="Second contribution" -v -e="${crypto.randomBytes(16).toString('hex')}"`)
+        execPrint(`snarkjs zkey beacon ${path.join(setup, 'rln_0002.zkey')} ${path.join(setup, 'final.zkey')} 0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 10 -n="Final Beacon phase2"`)
+        // Copy intermediate setup files
+        rmSync(path.join(dest, scheme, 'setup'), {recursive: true, force: true})
+        mkdirSync(path.join(dest, scheme, 'setup'), {recursive: true})
+        renameSync(path.join(setup, 'rln_0000.zkey'), path.join(dest, scheme, 'setup', 'rln_0000.zkey'))
+        renameSync(path.join(setup, 'rln_0001.zkey'), path.join(dest, scheme, 'setup', 'rln_0001.zkey'))
+        renameSync(path.join(setup, 'rln_0002.zkey'), path.join(dest, scheme, 'setup', 'rln_0002.zkey'))
+    } else if (scheme == 'plonk') {
+        execPrint(`snarkjs plonk setup ${name}.r1cs ${tauFile} ${path.join(setup, 'final.zkey')} `)
+    } else if (scheme == 'fflonk') {
+        execPrint(`snarkjs fflonk setup ${name}.r1cs ${tauFile} ${path.join(setup, 'final.zkey')} `)
+    } else {
+        console.error("Invalid scheme")
+        return
+    }
+    execPrint(`snarkjs zkey export verificationkey ${path.join(setup, 'final.zkey')} ${path.join(dest, scheme, 'verification_key.json')}`)
+    execPrint(`snarkjs zkey export solidityverifier ${path.join(setup, 'final.zkey')}  ${path.join(dest, scheme, 'verifier.sol')}`)
+    renameSync(path.join(setup, 'final.zkey'), path.join(dest, scheme, 'final.zkey'))
+    process.chdir(root)
+    rmSync(build, {recursive: true})
+}
+
+// run('rln-same', 'groth16', "powersOfTau28_hez_final_17.ptau")
+// run('rln-generic', 'plonk', "powersOfTau28_hez_final_17.ptau")
+run('rln-generic', 'groth16', "powersOfTau28_hez_final_17.ptau")

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,7 @@ async function run(name, scheme, tauname) {
             await downloadFile(tauURL, tauFile)
         } catch (e) {
             console.error(e)
-            process.exit()
+            process.exit(1)
         }
     }
     rmSync(build, {recursive: true, force: true})


### PR DESCRIPTION
There's a bash buildscript already included in the repository, but that only works on posix systems, so I wrote a buildscript in JS which should work anywhere, and added some features and changed behaviour to fix some shortcomings of the previous script.

I think you might want to consider including it in the main repository, given the compatibility advantage, though perhaps you'll change the behaviour somewhat to suit your requirements.

This seems to work on windows, macOS and Linux just fine.
Also, since it runs from `npm run build`, it doesn't require snarkjs to be installed globally, just `npm i` works assuming you already have circom.

Since I am also experimenting with plonks, it lets you select the scheme and works for all 3 snarkjs supported options (groth16, plonk, fflonk).

In order to select what circuits to build and which proving schemes to use, as well as which version of the powers of tau ceremony to pull, you can edit the build() function, for example commenting out something you do not need:

```Javascript
async function build() {
    await run('rln-same', 'groth16', "powersOfTau28_hez_final_17.ptau")
    await run('rln-generic', 'plonk', "powersOfTau28_hez_final_17.ptau")
    await run('rln-generic', 'groth16', "powersOfTau28_hez_final_17.ptau")
    process.exit()
}
```

I wanted a cleaner, more organized output folder structure, because I am trying to work with multiple proofs and trying out multiple schemes.
The build directory is only used as scratch space, as such **it is deleted before and after each run**.

Instead, completed circuits are copied to the top level `compiled` folder.
This is what it looks like:

<img width="289" alt="Screenshot 2023-03-22 at 08 27 59" src="https://user-images.githubusercontent.com/87247753/226926596-483c72d2-57d5-4842-9a00-c44390ed9aac.png">
So, one folder per circuit filename, and for scheme specific files a folder within that.

Tau ceremony files are saved in the `tau` folder which is in .gitignore.
This is to prevent them from being deleted as the build folder is deleted after each run now.

I didn't add the `compiled` folder to gitignore because compiled circuits with their setups need to be versioned. I need to ensure all deployments of my app are using the same proving and verifying keys.
It might make sense for you to keep it in gitignore until you do a formal ceremony.



