### PR TITLE
Fix test name typo in rln-same.test.ts

### DIFF
--- a/test/rln-same.test.ts
+++ b/test/rln-same.test.ts
@@ -10,7 +10,7 @@ const circuitPath = path.join(__dirname, "..", "circuits", "rln-same.circom");
 type CircuitT = any;
 
 
-describe("Test rln-diff.circom", function () {
+describe("Test rln-same.circom", function () {
     let circuit: CircuitT;
 
     this.timeout(30000);


### PR DESCRIPTION
## What this PR is doing?
- Fix typo discovered by audit: rln-diff -> rln-same