### PR TITLE
Fix tests due to circuit changes

### DIFF
--- a/test/rln-diff.test.ts
+++ b/test/rln-diff.test.ts
@@ -66,7 +66,7 @@ describe("Test rln-diff.circom", function () {
         assert.equal(outputNullifier, nullifier)
     });
 
-    it("should fail to generate witness if messageId is not in range [1, userMessageLimit]", async function () {
+    it("should fail to generate witness if messageId is not in range [0, userMessageLimit-1]", async function () {
         // Public inputs
         const x = genFieldElement();
         const externalNullifier = genFieldElement();
@@ -75,8 +75,8 @@ describe("Test rln-diff.circom", function () {
         const identitySecretCommitment = poseidon([identitySecret]);
         const merkleProof = genMerkleProof([identitySecretCommitment], 0)
         const userMessageLimit = BigInt(10)
-        // valid message id is in the range [1, userMessageLimit]
-        const invalidMessageIds = [BigInt(0), userMessageLimit + BigInt(1)]
+        // valid message id is in the range [0, userMessageLimit-1]
+        const invalidMessageIds = [userMessageLimit, userMessageLimit + BigInt(1)]
 
         for (const invalidMessageId of invalidMessageIds) {
             const inputs = {

--- a/test/rln-same.test.ts
+++ b/test/rln-same.test.ts
@@ -67,8 +67,8 @@ describe("Test rln-same.circom", function () {
         const identitySecretCommitment = poseidon([identitySecret]);
         const merkleProof = genMerkleProof([identitySecretCommitment], 0)
         const messageLimit = BigInt(10)
-        // valid message id is in the range [1, messageLimit]
-        const invalidMessageIds = [BigInt(0), messageLimit + BigInt(1)]
+        // valid message id is in the range [0, messageLimit-1]
+        const invalidMessageIds = [messageLimit, messageLimit + BigInt(1)]
 
         for (const invalidMessageId of invalidMessageIds) {
             const inputs = {

--- a/test/withdraw.test.ts
+++ b/test/withdraw.test.ts
@@ -23,9 +23,9 @@ describe("Test withdraw.circom", function () {
         // Private inputs
         const identitySecret = genFieldElement();
         // Public inputs
-        const addressHash = genFieldElement();
+        const address = genFieldElement();
         // Test: should generate proof if inputs are correct
-        const witness: bigint[] = await circuit.calculateWitness({identitySecret, addressHash}, true);
+        const witness: bigint[] = await circuit.calculateWitness({identitySecret, address}, true);
         await circuit.checkConstraints(witness);
         const expectedIdentityCommitment = poseidon([identitySecret])
         const outputIdentityCommitment = await getSignal(circuit, witness, "identityCommitment")


### PR DESCRIPTION
## What's changed?
- rln-diff.test.ts: the range of valid message id has become `[0, messageLimit-1]` 
- rln-same.test.ts: the range of valid message id has become `[0, messageLimit-1]`
- withdraw.test.ts: `addressHash` has been renamed to `address`