### PR TITLE
fix: add dummy constraint for unused input

### DIFF
--- a/circuits/withdraw.circom
+++ b/circuits/withdraw.circom
@@ -7,6 +7,9 @@ template Withdraw() {
     signal input address;
 
     signal output identityCommitment <== Poseidon(1)([identitySecret]);
+
+    // Dummy constraint to prevent compiler optimizing it
+    signal addressHashed <== address * address;
 }
 
 component main { public [address] } = Withdraw();


### PR DESCRIPTION
Issues zBlock-1/RLN-audit-report#1 zBlock-1/RLN-audit-report#2 zBlock-1/RLN-audit-report#3 zBlock-1/RLN-audit-report#4 zBlock-1/RLN-audit-report#5 zBlock-1/RLN-audit-report#6 zBlock-1/RLN-audit-report#7 zBlock-1/RLN-audit-report#9 zBlock-1/RLN-audit-report#10 mentioned "Unused public input ..." security bug.
This PR fixes it!