### PR TITLE
feat: use RLN with RC instead of Poseidon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/rc-impls"]
+	path = lib/rc-impls
+	url = https://github.com/rymnc/reinforced-concrete-impls

--- a/README.md
+++ b/README.md
@@ -3,13 +3,52 @@
     <img src="https://github.com/Rate-Limiting-Nullifier/rln-circuits-v2/workflows/Test/badge.svg" width="110">
 </p>
 
-<div align="center">
-
-*The project was audited by Veridise, yAcademy fellows and internally.*
-
-</div>
-
 ___
+
+## This is a fork of RLN
+
+This fork of RLN makes use of [RC hash function](https://rc-hash.info) as a drop in replacement to poseidon.
+
+
+### Constraint differences
+
+1. RLN Circuit =>
+
+```diff
+circom compiler 2.1.5
+-template instances: 216
++template instances: 48
+-non-linear constraints: 5820
++non-linear constraints: 957
+linear constraints: 0
+public inputs: 2
+public outputs: 3
+private inputs: 43
+private outputs: 0
+-wires: 5844
++wires: 1053
+-labels: 18553
++labels: 24733
+```
+
+2. Withdraw Circuit =>
+
+```diff
+circom compiler 2.1.5
+-template instances: 71
++template instances: 42
+-non-linear constraints: 214
++non-linear constraints: 37
+linear constraints: 0
+public inputs: 1
+public outputs: 1
+private inputs: 1
+private outputs: 0
+-wires: 217
++wires: 43
+-labels: 585
++labels: 1021
+```
 
 ## What's RLN?
 

--- a/circuits/utils.circom
+++ b/circuits/utils.circom
@@ -1,6 +1,6 @@
 pragma circom 2.1.0;
 
-include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../lib/rc-impls/rc-circom/circuits/reinforcedConcrete.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
 include "../node_modules/circomlib/circuits/bitify.circom";
 include "../node_modules/circomlib/circuits/comparators.circom";
@@ -27,7 +27,7 @@ template MerkleTreeInclusionProof(DEPTH) {
             pathIndex[i]
         );
 
-        levelHashes[i + 1] <== Poseidon(2)([mux[i][0], mux[i][1]]);
+        levelHashes[i + 1] <== ReinforcedConcreteHash()([mux[i][0], mux[i][1]]);
     }
 
     root <== levelHashes[DEPTH];

--- a/circuits/withdraw.circom
+++ b/circuits/withdraw.circom
@@ -1,12 +1,12 @@
 pragma circom 2.1.0;
 
-include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../lib/rc-impls/rc-circom/circuits/reinforcedConcrete.circom";
 
 template Withdraw() {
     signal input identitySecret;
     signal input address;
 
-    signal output identityCommitment <== Poseidon(1)([identitySecret]);
+    signal output identityCommitment <== ReinforcedConcreteHash()([identitySecret, 0]);
 
     // Dummy constraint to prevent compiler optimizing it
     signal addressSquared <== address * address;


### PR DESCRIPTION
With the implementation of the [RC hash](https://rc-hash.info) in [circom](https://github.com/rymnc/reinforced-concrete-impls), we can substitute it instead of Poseidon in the calculation of - 
a. `identityCommitment`
b. `rateCommitment`
c. `a1`
d. `levelHashes` in the `MerkleInclusionProof`


Here's the diff of constraints for both the `RLN` and `withdraw` circuits

1. RLN Circuit =>

```diff
circom compiler 2.1.5
-template instances: 216
+template instances: 48
-non-linear constraints: 5820
+non-linear constraints: 957
linear constraints: 0
public inputs: 2
public outputs: 3
private inputs: 43
private outputs: 0
-wires: 5844
+wires: 1053
-labels: 18553
+labels: 24733
```

2. Withdraw Circuit =>

```diff
circom compiler 2.1.5
-template instances: 71
+template instances: 42
-non-linear constraints: 214
+non-linear constraints: 37
linear constraints: 0
public inputs: 1
public outputs: 1
private inputs: 1
private outputs: 0
-wires: 217
+wires: 43
-labels: 585
+labels: 1021
```

